### PR TITLE
Fix small input handling

### DIFF
--- a/deepmreye/pytorch_architecture.py
+++ b/deepmreye/pytorch_architecture.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import math
 
 
 class Conv3dBlock(nn.Module):
@@ -146,10 +147,14 @@ class StandardModel(nn.Module):
         self.first = Conv3dBlock(channels, opts["filters"], opts["kernel"], 1, act)
         self.dropout = nn.Dropout3d(opts["dropout_rate"])
 
+        # ensure that downsampling does not reduce spatial dimensions below 1
+        max_downsamples = int(math.log2(max(1, min(x, y, z))))
+        depth = min(opts["depth"], max_downsamples + 1)
+
         self.down = DownsampleBlock(
             opts["filters"],
             opts["filters"],
-            opts["depth"],
+            depth,
             opts["multiplier"],
             opts["groups"],
             act,


### PR DESCRIPTION
## Summary
- adjust pooling depth dynamically when spatial dimensions are small

## Testing
- `pytest -q` *(fails: no tests found)*
